### PR TITLE
feat: events api get by status and genre

### DIFF
--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -54,11 +54,12 @@ export class EventController {
   @Get('status')
   @getEventsByStatusSwagger()
   async getEventByStatus(
+    @User('role') role: string,
     @Query('status') type: string = 'all',
-    @User('role') role: string
+    @Query('genre') genre?: string
   ) {
     const isAdmin = role === 'admin';
-    return this.eventService.getEventsByStatus(type, isAdmin);
+    return this.eventService.getEventsByStatus(type, isAdmin, genre);
   }
 
   @Get('userEventList/:userId')
@@ -76,10 +77,12 @@ export class EventController {
   @Get('find')
   @findEventsSwagger()
   async findEvents(
+    @User('role') role: string,
     @Query('keyword') keyword?: string,
     @Query('type') type?: 'trending' | 'upcoming'
   ) {
-    return this.eventService.findEvents(keyword, type);
+    const isAdmin = role === 'admin';
+    return this.eventService.findEvents(keyword, type, isAdmin);
   }
 
   @Get(':id?')

--- a/src/event/event.swagger.ts
+++ b/src/event/event.swagger.ts
@@ -171,7 +171,7 @@ export const getEventTypeSwagger = () => {
 export const getEventsByStatusSwagger = () => {
   return applyDecorators(
     ApiTags('events'),
-    ApiOperation({ summary: 'Get events by status' }),
+    ApiOperation({ summary: 'Get events by status and optional genre' }),
     ApiBearerAuth(),
     ApiQuery({
       name: 'status',
@@ -180,6 +180,20 @@ export const getEventsByStatusSwagger = () => {
       required: false,
       example: 'all',
       schema: { default: 'all' },
+    }),
+    ApiQuery({
+      name: 'genre',
+      required: false,
+      enum: [
+        'Music',
+        'Comedy',
+        'Educational',
+        'Health&Wellness',
+        'Workshop',
+        'Promotion',
+      ],
+      description: 'Genre of the event (e.g., Music, Comedy, etc.)',
+      example: 'Music',
     }),
     ApiOkResponse({ description: 'Successfully fetched events' }),
     ApiBadRequestResponse({ description: 'Invalid input data' })

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { UserEvent } from '../user-event/user-event.entity';
-import { Session } from 'src/auth/session.entity';
+import { Session } from '../auth/session.entity';
 
 @Entity()
 export class User {


### PR DESCRIPTION
- API `/events/status` updated -> accepts two query params:
    - status -> ["all", "upcoming", "current", "past", "trending"] (default: "all")
    - genre -> (Optional)